### PR TITLE
Update wrapper for ADP inclusion

### DIFF
--- a/R/wrapper.R
+++ b/R/wrapper.R
@@ -64,8 +64,7 @@ proc_ace_complete <- function (path_in,
                                                      "COLORSELECTION.max_delay_time",
                                                      "rcs.overall"),
                                post_metric_names_exclude = c("FILTER.rcs",
-                                                             "TNT.rt_mean.correct.",
-                                                             "ADP.rcs")) {
+                                                             "TNT.rt_mean.correct.")) {
   if(data_type == "explorer") {
     app_type <- "explorer"
   } else {


### PR DESCRIPTION
ADP.rcs was in exclude_names. Removed so it will now be included.