### PR TITLE
Update to exclude new sdt_counts from scrub

### DIFF
--- a/R/module-post.R
+++ b/R/module-post.R
@@ -268,6 +268,10 @@ post_clean_low_trials <- function (df,
                                                 !grepl("cost", names(.x)) & 
                                                 !grepl("start", names(.x)) & 
                                                 !grepl("early", names(.x)) & 
+                                                !grepl("hit", names(.x)) & 
+                                                !grepl("miss", names(.x)) & 
+                                                !grepl("cr", names(.x)) & 
+                                                !grepl("fa", names(.x)) & 
                                                 !grepl("practice", names(.x))]),
            filter_cols = map_if(filter_cols, module == "SAAT", ~.x[!grepl("overall", .x)], .else = ~.x),
            non_demo_cols = map(proc, ~names(.x)[!(names(.x) %in% valid_demos)]),


### PR DESCRIPTION
Remove sdt_count_hit, sdt_count_miss, sdt_count_cr, and sdt_count_fa from post_clean_low_trials function