### PR TITLE
Add .github/workflows/ci.yml for continuous testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: aceR-continuous-integration 
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: aceR-continuous-integration 
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up R
+      uses: r-lib/actions/setup-r@v2
+
+    - name: Install renv
+      run: install.packages('renv')
+      shell: Rscript {0}
+
+    - name: Restore dependencies
+      run: renv::restore()
+      shell: Rscript {0}
+
+    - name: Run tests
+      run: |
+        install.packages('testthat')
+        testthat::test_dir('tests')
+      shell: Rscript {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
 
     - name: Set up R
       uses: r-lib/actions/setup-r@v2
+      with:
+        r-version: '4.0.5' # must be consistent with renv.lock
 
     - name: Install renv
       run: install.packages('renv')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: R
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        r-version: ['3.6.3', '4.1.1']
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up R ${{ matrix.r-version }}
+        uses: r-lib/actions/setup-r@f57f1301a053485946083d7a45022b278929a78a
+        with:
+          r-version: ${{ matrix.r-version }}
+      - name: Install dependencies
+        run: |
+          install.packages(c("remotes", "rcmdcheck"))
+          remotes::install_deps(dependencies = TRUE)
+        shell: Rscript {0}
+      - name: Check
+        run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "error")
+        shell: Rscript {0}

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ scripts/*.html
 scripts/seacrest/*spin
 scripts/*.html
 scratchpad.R
+example.R
 ~/.boxr-oauth
 ignore/*


### PR DESCRIPTION
Adds a workflow file for continuous integration / testing on pull requests made to the repository. [Github Actions](https://docs.github.com/en/actions/automating-builds-and-tests/about-continuous-integration) is free for public repositories and has a rich plugin ecosystem for R. 

The workflow file is set up to:
- Run on all pull requests & pushes to master
- The workflow will checkout this repository, install R 4.05
- Install renv and all the dependencies specified in the repository
- Run all tests using `testthat`